### PR TITLE
Support label management through UI

### DIFF
--- a/frontend/src/resources/utils/resource-request.ts
+++ b/frontend/src/resources/utils/resource-request.ts
@@ -1,10 +1,11 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { getResourceApiPath, getResourceName, getResourceNameApiPath, IResource, ResourceList } from '../resource'
+import { getResourceApiPath, getResourcePlural, getResourceName, getResourceNameApiPath, IResource, ResourceList } from '../resource'
 import { Status, StatusKind } from '../status'
 import { AnsibleTowerJobTemplateList } from '../ansible-job'
 
 export const backendUrl = `${process.env.REACT_APP_BACKEND_HOST}` + `${process.env.REACT_APP_BACKEND_PATH}`
+export const restBackendPath = '/hub-of-hubs-nonk8s-api/'
 
 export interface IRequestResult<ResultType = unknown> {
     promise: Promise<ResultType>
@@ -66,6 +67,20 @@ export function patchResource<Resource extends IResource, ResultType = Resource>
     data: unknown
 ): IRequestResult<ResultType> {
     const url = backendUrl + getResourceNameApiPath(resource)
+    const headers: Record<string, string> = {}
+    if (Array.isArray(data)) {
+        headers['Content-Type'] = 'application/json-patch+json'
+    } else {
+        headers['Content-Type'] = 'application/merge-patch+json'
+    }
+    return patchRequest<unknown, ResultType>(url, data, headers)
+}
+
+export function patchRestResource<Resource extends IResource, ResultType = Resource>(
+    resource: Resource,
+    data: unknown
+): IRequestResult<ResultType> {
+    const url = backendUrl + restBackendPath + getResourcePlural(resource) + '/' + getResourceName(resource)
     const headers: Record<string, string> = {}
     if (Array.isArray(data)) {
         headers['Content-Type'] = 'application/json-patch+json'

--- a/frontend/src/resources/utils/resource-request.ts
+++ b/frontend/src/resources/utils/resource-request.ts
@@ -5,7 +5,7 @@ import { Status, StatusKind } from '../status'
 import { AnsibleTowerJobTemplateList } from '../ansible-job'
 
 export const backendUrl = `${process.env.REACT_APP_BACKEND_HOST}` + `${process.env.REACT_APP_BACKEND_PATH}`
-export const restBackendPath = '/hub-of-hubs-nonk8s-api/'
+export const nonk8sBackendPath = `${process.env.REACT_APP_NONKUBERNETES_API_PATH}`
 
 export interface IRequestResult<ResultType = unknown> {
     promise: Promise<ResultType>
@@ -76,11 +76,11 @@ export function patchResource<Resource extends IResource, ResultType = Resource>
     return patchRequest<unknown, ResultType>(url, data, headers)
 }
 
-export function patchRestResource<Resource extends IResource, ResultType = Resource>(
+export function patchNonk8sResource<Resource extends IResource, ResultType = Resource>(
     resource: Resource,
     data: unknown
 ): IRequestResult<ResultType> {
-    const url = backendUrl + restBackendPath + getResourcePlural(resource) + '/' + getResourceName(resource)
+    const url = backendUrl + nonk8sBackendPath + '/' + getResourcePlural(resource) + '/' + getResourceName(resource)
     const headers: Record<string, string> = {}
     if (Array.isArray(data)) {
         headers['Content-Type'] = 'application/json-patch+json'

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
@@ -38,6 +38,7 @@ import { DiscoveryBanner } from '../DiscoveredClusters/DiscoveryComponents/Banne
 import { AddCluster } from './components/AddCluster'
 import { BatchChannelSelectModal } from './components/BatchChannelSelectModal'
 import { BatchUpgradeModal } from './components/BatchUpgradeModal'
+import { ClusterActionDropdown } from './components/ClusterActionDropdown'
 import { DistributionField } from './components/DistributionField'
 import { StatusField } from './components/StatusField'
 import { useAllClusters } from './components/useAllClusters'
@@ -301,6 +302,13 @@ export function ClustersTable(props: {
                                 '-'
                             )
                         },
+                    },
+                    {
+                        header: '',
+                        cell: (cluster: Cluster) => {
+                            return <ClusterActionDropdown cluster={cluster} isKebab={true} />
+                        },
+                        cellTransforms: [fitContent],
                     },
                 ]}
                 keyFn={mckeyFn}

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.tsx
@@ -357,6 +357,9 @@ export function ClusterActionDropdown(props: { cluster: Cluster; isKebab: boolea
         actions = actions.filter((a) => a.id !== 'ai-edit')
     }
 
+    // for Hub-of-Hubs leave only 'edit-labels' action
+    actions = actions.filter((a) => a.id === 'edit-labels')
+
     return (
         <>
             <EditLabels

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditLabels.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditLabels.tsx
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { IResource, patchRestResource } from '../../../../../resources'
+import { IResource, patchNonk8sResource } from '../../../../../resources'
 import {
     AcmAlertContext,
     AcmAlertGroup,
@@ -96,7 +96,7 @@ export function EditLabels(props: { resource?: IResource; displayName?: string; 
                                         })
                                     }
 
-                                    return patchRestResource(resource!, patch)
+                                    return patchNonk8sResource(resource!, patch)
                                         .promise.then(() => {
                                             props.close()
                                         })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditLabels.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/EditLabels.tsx
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { IResource, patchResource } from '../../../../../resources'
+import { IResource, patchRestResource } from '../../../../../resources'
 import {
     AcmAlertContext,
     AcmAlertGroup,
@@ -96,7 +96,7 @@ export function EditLabels(props: { resource?: IResource; displayName?: string; 
                                         })
                                     }
 
-                                    return patchResource(resource!, patch)
+                                    return patchRestResource(resource!, patch)
                                         .promise.then(() => {
                                             props.close()
                                         })

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -62,6 +62,7 @@ module.exports = function (_env: any, argv: { hot?: boolean; mode: string | unde
                     ? JSON.stringify('')
                     : JSON.stringify('https://localhost:4000'),
                 'process.env.REACT_APP_BACKEND_PATH': JSON.stringify('/multicloud'),
+		'process.env.REACT_APP_NONKUBERNETES_API_PATH': JSON.stringify('/hub-of-hubs-nonk8s-api'),
             }) as unknown as webpack.WebpackPluginInstance,
             new webpack.ProvidePlugin({ Buffer: ['buffer', 'Buffer'], process: 'process' }),
             new MonacoWebpackPlugin({ languages: ['yaml'] }),


### PR DESCRIPTION
- Re-add edit-labels option for managed clusters in clusters view
- Use nonk8s api for requests
- Sync change in labels state (added labels and delete labels) instead of sending ALL present labels